### PR TITLE
Suppress unused wariables warnings

### DIFF
--- a/include/boost/interprocess/mapped_region.hpp
+++ b/include/boost/interprocess/mapped_region.hpp
@@ -741,6 +741,9 @@ inline bool mapped_region::advise(advice_types advice)
    const unsigned int mode_none = 0;
    const unsigned int mode_padv = 1;
    const unsigned int mode_madv = 2;
+   (void)mode_padv; // Suppress "unused variable 'mode_padv'" warining
+   (void)mode_madv; // Suppress "unused variable 'mode_madv'" warining
+
    unsigned int mode = mode_none;
    //Choose advice either from POSIX (preferred) or native Unix
    switch(advice){


### PR DESCRIPTION
On a platforms (Android) that do not define `POSIX_MADV_NORMAL` or `MADV_NORMAL` variables `mode_padv` and `mode_madv` won't be used. In that case compiler will produce a "unused variable" warning.

This patch suppresses the "unused variable" warnings for `mode_padv` and `mode_madv`.
