### PR TITLE
Provide support for the Cray C++ compiler.  The Cray compiler defines __...

### DIFF
--- a/include/boost/interprocess/detail/atomic.hpp
+++ b/include/boost/interprocess/detail/atomic.hpp
@@ -93,7 +93,7 @@ inline boost::uint32_t atomic_cas32
 }  //namespace interprocess{
 }  //namespace boost{
 
-#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__)) && !defined(_CRAYC)
 
 namespace boost {
 namespace interprocess {

--- a/include/boost/interprocess/sync/spin/wait.hpp
+++ b/include/boost/interprocess/sync/spin/wait.hpp
@@ -37,7 +37,7 @@ extern "C" void _mm_pause();
 
 #define BOOST_INTERPROCESS_SMT_PAUSE _mm_pause();
 
-#elif defined(__GNUC__) && ( defined(__i386__) || defined(__x86_64__) )
+#elif defined(__GNUC__) && ( defined(__i386__) || defined(__x86_64__) ) && !defined(_CRAYC)
 
 #define BOOST_INTERPROCESS_SMT_PAUSE __asm__ __volatile__( "rep; nop" : : : "memory" );
 


### PR DESCRIPTION
The Cray C++ compiler defines **GNUC** and generally supports gnu extensions to C and C++. 
It does not, however, support inline assembly.  The changes here are to avoid inline assembly when
_CRAYC is asserted in the preprocessor.
