### PR TITLE
Variable name hz conflicts with the definition of an AIX system variable

### DIFF
--- a/include/boost/interprocess/detail/os_thread_functions.hpp
+++ b/include/boost/interprocess/detail/os_thread_functions.hpp
@@ -283,6 +283,11 @@ typedef struct timespec OS_highres_count_t;
 typedef unsigned long long OS_highres_count_t;
 #endif
 
+#ifdef _AIX
+// In AIX variable name hz conflicts with the definition of an AIX system variable
+#undef hz
+#endif
+
 inline unsigned long get_system_tick_ns()
 {
    #ifdef _SC_CLK_TCK


### PR DESCRIPTION
Having a variable named hz conflicts with the definition of an AIX system variable that is in scope with this file. If I undefine the variable hz, hz can be safely defined without any confusion.
