### PR TITLE
Fix compilation error in MinGW, invalid return type (pointer to function...

### DIFF
--- a/include/boost/interprocess/detail/win32_api.hpp
+++ b/include/boost/interprocess/detail/win32_api.hpp
@@ -1522,7 +1522,7 @@ struct function_address_holder
    }
 
    public:
-   static void *get(const unsigned int id)
+   static farproc_t get(const unsigned int id)
    {
       BOOST_ASSERT(id < (unsigned int)NumFunction);
       for(unsigned i = 0; FunctionStates[id] < 2; ++i){


### PR DESCRIPTION
...)
