### PR TITLE
Compile fix for BOOST_USE_WINDOWS_H

### DIFF
--- a/include/boost/interprocess/mapped_region.hpp
+++ b/include/boost/interprocess/mapped_region.hpp
@@ -374,7 +374,7 @@ template<int dummy>
 inline std::size_t mapped_region::page_size_holder<dummy>::get_page_size()
 {
    winapi::system_info info;
-   get_system_info(&info);
+   winapi::get_system_info(&info);
    return std::size_t(info.dwAllocationGranularity);
 }
 


### PR DESCRIPTION
If BOOST_USE_WINDOWS_H is defined, the call to get_system_info has to be qualified with an explicit namespace.

I must have forgotten this in #11, sorry.
