### PR TITLE
Update gcc version diagnostic pragmas; reported by Shane Turner

### DIFF
--- a/include/boost/interprocess/detail/config_begin.hpp
+++ b/include/boost/interprocess/detail/config_begin.hpp
@@ -44,7 +44,7 @@
    #pragma warning (disable : 4250) //  inherits 'x' via dominance
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40000)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif

--- a/include/boost/interprocess/detail/config_end.hpp
+++ b/include/boost/interprocess/detail/config_end.hpp
@@ -11,6 +11,6 @@
    #pragma warning (pop)
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40000)
+#if defined(BOOST_GCC) && (BOOST_GCC >= 40600)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Shane wrote:
> I found another issue with a bad compiler version check in boost/interprocess/detail/config_begin.hpp before using "#pragma GCC diagnostic push", which, for GCC, is only available at version 4.6.0 and later. Since I'm using GCC 4.4.7, my compile fails.

Updated the version check to only fire on 4.6 and later.
