### PR TITLE
Adding wchar_t* file name support for file_mapping constructor

### DIFF
--- a/include/boost/interprocess/detail/os_file_functions.hpp
+++ b/include/boost/interprocess/detail/os_file_functions.hpp
@@ -145,6 +145,14 @@ inline file_handle_t open_existing_file
       (name, (unsigned int)mode, winapi::open_existing, attr, 0);
 }
 
+inline file_handle_t open_existing_file
+   (const wchar_t *name, mode_t mode = read_write, bool temporary = false)
+{
+   unsigned long attr = temporary ? winapi::file_attribute_temporary : 0;
+   return winapi::create_file
+      (name, (unsigned int)mode, winapi::open_existing, attr, 0);
+}
+
 inline bool delete_file(const char *name)
 {  return winapi::unlink_file(name);   }
 

--- a/include/boost/interprocess/detail/win32_api.hpp
+++ b/include/boost/interprocess/detail/win32_api.hpp
@@ -870,6 +870,7 @@ extern "C" __declspec(dllimport) int __stdcall DuplicateHandle
    , unsigned long dwDesiredAccess, int bInheritHandle
    , unsigned long dwOptions);
 extern "C" __declspec(dllimport) long __stdcall GetFileType(void *hFile);
+extern "C" __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int, unsigned long, const wchar_t*, int, char*, int, const char*, int*);
 extern "C" __declspec(dllimport) void *__stdcall FindFirstFileA(const char *lpFileName, win32_find_data *lpFindFileData);
 extern "C" __declspec(dllimport) int   __stdcall FindNextFileA(void *hFindFile, win32_find_data *lpFindFileData);
 extern "C" __declspec(dllimport) int   __stdcall FindClose(void *hFindFile);
@@ -887,6 +888,7 @@ extern "C" __declspec(dllimport) void * __stdcall CreateFileMappingA (void *, in
 extern "C" __declspec(dllimport) void * __stdcall MapViewOfFileEx (void *, unsigned long, unsigned long, unsigned long, std::size_t, void*);
 extern "C" __declspec(dllimport) void * __stdcall OpenFileMappingA (unsigned long, int, const char *);
 extern "C" __declspec(dllimport) void * __stdcall CreateFileA (const char *, unsigned long, unsigned long, struct interprocess_security_attributes*, unsigned long, unsigned long, void *);
+extern "C" __declspec(dllimport) void * __stdcall CreateFileW (const wchar_t *, unsigned long, unsigned long, struct interprocess_security_attributes*, unsigned long, unsigned long, void *);
 extern "C" __declspec(dllimport) void __stdcall GetSystemInfo (struct system_info *);
 extern "C" __declspec(dllimport) int __stdcall FlushViewOfFile (void *, std::size_t);
 extern "C" __declspec(dllimport) int __stdcall VirtualUnlock (void *, std::size_t);


### PR DESCRIPTION
Hi,

I'm a developer from Autodesk.  

More and more peoples in our company want to use file mapping cross platforms, but file_mapping of boost.interprocess  lacks of wide char file name supporting on Windows. I think it's valuable for us to support wide char file name.

-Jackson
