### PR TITLE
Conform to std::pointer_traits requirements

### DIFF
--- a/include/boost/interprocess/offset_ptr.hpp
+++ b/include/boost/interprocess/offset_ptr.hpp
@@ -444,9 +444,17 @@ class offset_ptr
 
    //!Compatibility with pointer_traits
    //!
+   #if defined(BOOST_NO_CXX11_TEMPLATE_ALIASES)
    template <class U>
    struct rebind
    {  typedef offset_ptr<U, DifferenceType, OffsetType, OffsetAlignment> other;  };
+   #else
+   template <class U>
+   using rebind = offset_ptr<U, DifferenceType, OffsetType, OffsetAlignment>;
+   #ifndef BOOST_INTERPROCESS_DOXYGEN_INVOKED
+   typedef offset_ptr<PointedType, DifferenceType, OffsetType, OffsetAlignment> other;
+   #endif //BOOST_INTERPROCESS_DOXYGEN_INVOKED
+   #endif
 
    //!Compatibility with pointer_traits
    //!


### PR DESCRIPTION
offset_ptr<T, ...>::rebind<U> must be offset_ptr<U, ...> directly

to avoid breaking older pointer_traits implementations (like in Visual Studio 2015),
'other' is added as typedef so offset_ptr<T, ...>::rebind< U >::other still works