### PR TITLE
Fixed options for cross-compilation.

### DIFF
--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -26,9 +26,9 @@ rule test_all
         <toolset>acc:<linkflags>-lrt
         <toolset>acc-pa_risc:<linkflags>-lrt
         <toolset>gcc,<target-os>windows:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
-        <host-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
-        <host-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
-        <host-os>linux:<linkflags>"-lrt"
+        <target-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
+        <target-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
+        <target-os>linux:<linkflags>"-lrt"
       :  # test-files
       :  # requirements
       ] ;
@@ -43,9 +43,9 @@ rule test_all
         <toolset>acc:<linkflags>-lrt
         <toolset>acc-pa_risc:<linkflags>-lrt
         <toolset>gcc-mingw:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
-        <host-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
-        <host-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
-        <host-os>linux:<linkflags>"-lrt"
+        <target-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
+        <target-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
+        <target-os>linux:<linkflags>"-lrt"
       ] ;
    }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -28,9 +28,9 @@ rule test_all
         <toolset>acc:<linkflags>-lrt
         <toolset>acc-pa_risc:<linkflags>-lrt
         <toolset>gcc,<target-os>windows:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
-        <host-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
-        <host-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
-        <host-os>linux:<linkflags>"-lrt"
+        <target-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
+        <target-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
+        <target-os>linux:<linkflags>"-lrt"
       ] ;
    }
 


### PR DESCRIPTION
Replaced \<host-os\> with \<target-os\> so that the correct options for the target are selected when cross-compiling. When not cross-compiling, it makes no difference as target-os by default mirrors host-os.

Without this, I get the linker error "cannot find -lrt" on my regression test runner for QNX 6.6.0 which is cross-compiling from Linux to QNX.