### PR TITLE
Conditionally replace deprecated/removed std::auto_ptr by std::unique…

### DIFF
--- a/include/boost/interprocess/indexes/iunordered_set_index.hpp
+++ b/include/boost/interprocess/indexes/iunordered_set_index.hpp
@@ -89,8 +89,10 @@ struct iunordered_set_index_aux
    };
 
     struct hash_function
-      : std::unary_function<value_type, std::size_t>
     {
+        typedef value_type argument_type;
+        typedef std::size_t result_type;
+
         std::size_t operator()(const value_type &val) const
         {
             const char_type *beg = ipcdetail::to_raw_pointer(val.name()),

--- a/include/boost/interprocess/indexes/unordered_map_index.hpp
+++ b/include/boost/interprocess/indexes/unordered_map_index.hpp
@@ -22,7 +22,6 @@
 #include <boost/interprocess/detail/config_begin.hpp>
 #include <boost/interprocess/detail/workaround.hpp>
 
-#include <functional>
 #include <boost/intrusive/detail/minimal_pair_header.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/interprocess/detail/utilities.hpp>
@@ -54,8 +53,10 @@ struct unordered_map_index_aux
                typename MapConfig::
                   segment_manager_base>      allocator_type;
     struct hasher
-      : std::unary_function<key_type, std::size_t>
     {
+        typedef key_type argument_type;
+        typedef std::size_t result_type;
+
         std::size_t operator()(const key_type &val) const
         {
             typedef typename key_type::char_type    char_type;

--- a/test/message_queue_test.cpp
+++ b/test/message_queue_test.cpp
@@ -251,7 +251,11 @@ bool test_buffer_overflow()
 {
    boost::interprocess::message_queue::remove(test::get_process_id_name());
    {
+#ifdef BOOST_NO_AUTO_PTR
+      std::unique_ptr<boost::interprocess::message_queue>
+#else
       std::auto_ptr<boost::interprocess::message_queue>
+#endif
          ptr(new boost::interprocess::message_queue
                (create_only, test::get_process_id_name(), 10, 10));
       pmessage_queue = ptr.get();


### PR DESCRIPTION
…_ptr. Inline typedefs from deprecated/removed C++98 function adapters.

Signed-off-by: Daniela Engert <dani@ngrt.de>