### PR TITLE
Fix misformatted code samples in the documentation

### DIFF
--- a/doc/interprocess.qbk
+++ b/doc/interprocess.qbk
@@ -3350,7 +3350,9 @@ To use a managed mapped file, you must include the following header:
    //    file to implement managed features.
    //!!  If anything fails, throws interprocess_exception
    //
-   managed_mapped_file mfile      (create_only,      "MyMappedFile",   //Mapped file name      65536);           //Mapped file size
+   managed_mapped_file mfile      ( create_only
+                                  , "MyMappedFile" //Mapped file name
+                                  , 65536);        //Mapped file size
 [c++]
 
    //1.  Opens a file
@@ -3361,7 +3363,10 @@ To use a managed mapped file, you must include the following header:
    //    to implement managed features.
    //!!  If anything fails, throws interprocess_exception
    //
-   managed_mapped_file mfile      (open_only,      "MyMappedFile");  //Mapped file name[c++]
+   managed_mapped_file mfile      ( open_only
+                                  , "MyMappedFile"); //Mapped file name
+
+[c++]
 
    //1.  If the file was previously created
    //    equivalent to "open_only".
@@ -3369,7 +3374,10 @@ To use a managed mapped file, you must include the following header:
    //
    //!!  If anything fails, throws interprocess_exception
    //
-   managed_mapped_file mfile      (open_or_create,      "MyMappedFile",   //Mapped file name      65536);           //Mapped file size
+   managed_mapped_file mfile      (open_or_create
+                                  , "MyMappedFile" //Mapped file name
+                                  , 65536);        //Mapped file size
+
 When the `managed_mapped_file` object is destroyed, the file is
 automatically unmapped, and all the resources are freed. To remove
 the file from the filesystem you could use standard C `std::remove`


### PR DESCRIPTION
The current examples look strange since the C++-style comments result in the rest of the line being completely commented-out:

<img width="1246" alt="screen shot 2017-07-03 at 16 16 51" src="https://user-images.githubusercontent.com/700834/27810124-5afc334e-600b-11e7-82c3-2df2c67a4ce6.png">


This commit changes the way those parameters are documented to make them consistent with the rest of the documentation.

Note that I was unable to test this change because I wasn't able to generate the Boost documentation locally.