### PR TITLE
Make intrusive_ptr move constructible/assignable 

### DIFF
--- a/include/boost/interprocess/offset_ptr.hpp
+++ b/include/boost/interprocess/offset_ptr.hpp
@@ -34,6 +34,7 @@
 #include <boost/container/detail/type_traits.hpp>  //alignment_of, aligned_storage
 #include <boost/assert.hpp>
 #include <iosfwd>
+#include <iterator>
 
 //!\file
 //!Describes a smart pointer that stores the offset between this pointer and

--- a/include/boost/interprocess/smart_ptr/intrusive_ptr.hpp
+++ b/include/boost/interprocess/smart_ptr/intrusive_ptr.hpp
@@ -48,8 +48,8 @@ namespace interprocess {
 //!intrusive_ptr<T, offset_ptr<void> > defines a class with a offset_ptr<T> member.
 //!Relies on unqualified calls to:
 //!
-//!  void intrusive_ptr_add_ref(T * p);
-//!  void intrusive_ptr_release(T * p);
+//!  void intrusive_ptr_add_ref(T * p) BOOST_NOEXCEPT;
+//!  void intrusive_ptr_release(T * p) BOOST_NOEXCEPT;
 //!
 //!  with (p != 0)
 //!
@@ -75,53 +75,73 @@ class intrusive_ptr
    public:
    //!Constructor. Initializes internal pointer to 0.
    //!Does not throw
-   intrusive_ptr(): m_ptr(0)
+   intrusive_ptr() BOOST_NOEXCEPT
+	   : m_ptr(0)
    {}
 
    //!Constructor. Copies pointer and if "p" is not zero and
    //!"add_ref" is true calls intrusive_ptr_add_ref(to_raw_pointer(p)).
    //!Does not throw
-   intrusive_ptr(const pointer &p, bool add_ref = true): m_ptr(p)
+   intrusive_ptr(const pointer &p, bool add_ref = true) BOOST_NOEXCEPT
+	   : m_ptr(p)
    {
       if(m_ptr != 0 && add_ref) intrusive_ptr_add_ref(ipcdetail::to_raw_pointer(m_ptr));
    }
 
    //!Copy constructor. Copies the internal pointer and if "p" is not
    //!zero calls intrusive_ptr_add_ref(to_raw_pointer(p)). Does not throw
-   intrusive_ptr(intrusive_ptr const & rhs)
+   intrusive_ptr(intrusive_ptr const & rhs) BOOST_NOEXCEPT
       :  m_ptr(rhs.m_ptr)
    {
       if(m_ptr != 0) intrusive_ptr_add_ref(ipcdetail::to_raw_pointer(m_ptr));
    }
 
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+   //!Move constructor. Moves the internal pointer. Does not throw
+   intrusive_ptr(intrusive_ptr&& rhs) BOOST_NOEXCEPT
+	   : m_ptr(rhs.m_ptr) 
+   {
+	   rhs.m_ptr = 0;
+   }
+#endif
+
    //!Constructor from related. Copies the internal pointer and if "p" is not
    //!zero calls intrusive_ptr_add_ref(to_raw_pointer(p)). Does not throw
-   template<class U> intrusive_ptr
-      (intrusive_ptr<U, VP> const & rhs)
+   template<class U> intrusive_ptr(intrusive_ptr<U, VP> const & rhs) BOOST_NOEXCEPT
       :  m_ptr(rhs.get())
    {
       if(m_ptr != 0) intrusive_ptr_add_ref(ipcdetail::to_raw_pointer(m_ptr));
    }
 
-   //!Destructor. If internal pointer is not 0, calls
-   //!intrusive_ptr_release(to_raw_pointer(m_ptr)). Does not throw
+   //!Destructor. Calls reset(). Does not throw
    ~intrusive_ptr()
    {
-      if(m_ptr != 0) intrusive_ptr_release(ipcdetail::to_raw_pointer(m_ptr));
+      reset();
    }
 
    //!Assignment operator. Equivalent to intrusive_ptr(r).swap(*this).
    //!Does not throw
-   intrusive_ptr & operator=(intrusive_ptr const & rhs)
+   intrusive_ptr & operator=(intrusive_ptr const & rhs) BOOST_NOEXCEPT
    {
       this_type(rhs).swap(*this);
       return *this;
    }
 
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+   //!Move Assignment operator
+   //!Does not throw
+   intrusive_ptr & operator=(intrusive_ptr&& rhs) BOOST_NOEXCEPT 
+   {
+	   rhs.swap(*this);
+	   rhs.reset();
+	   return *this;
+   }
+#endif
+
    //!Assignment from related. Equivalent to intrusive_ptr(r).swap(*this).
    //!Does not throw
-   template<class U> intrusive_ptr & operator=
-      (intrusive_ptr<U, VP> const & rhs)
+   template<class U> intrusive_ptr & operator=(intrusive_ptr<U, VP> const & rhs) BOOST_NOEXCEPT
    {
       this_type(rhs).swap(*this);
       return *this;
@@ -129,50 +149,60 @@ class intrusive_ptr
 
    //!Assignment from pointer. Equivalent to intrusive_ptr(r).swap(*this).
    //!Does not throw
-   intrusive_ptr & operator=(pointer rhs)
+   intrusive_ptr & operator=(pointer rhs) BOOST_NOEXCEPT
    {
       this_type(rhs).swap(*this);
       return *this;
    }
 
+   //!Release internal pointer and set it to 0. If internal pointer is not 0, calls
+   //!intrusive_ptr_release(to_raw_pointer(m_ptr)). Does not throw
+   void reset() BOOST_NOEXCEPT {
+      if(m_ptr != 0) {
+        pointer ptr = m_ptr;
+        m_ptr = 0;
+        intrusive_ptr_release(ipcdetail::to_raw_pointer(ptr));
+      }
+   }
+
    //!Returns a reference to the internal pointer.
    //!Does not throw
-   pointer &get()
+   pointer &get() BOOST_NOEXCEPT
    {  return m_ptr;  }
 
    //!Returns a reference to the internal pointer.
    //!Does not throw
-   const pointer &get() const
+   const pointer &get() const BOOST_NOEXCEPT
    {  return m_ptr;  }
 
    //!Returns *get().
    //!Does not throw
-   T & operator*() const
+   T & operator*() const BOOST_NOEXCEPT
    {  return *m_ptr; }
 
    //!Returns *get().
    //!Does not throw
-   const pointer &operator->() const
+   const pointer &operator->() const BOOST_NOEXCEPT
    {  return m_ptr;  }
 
    //!Returns get().
    //!Does not throw
-   pointer &operator->()
+   pointer &operator->() BOOST_NOEXCEPT
    {  return m_ptr;  }
 
    //!Conversion to boolean.
    //!Does not throw
-   operator unspecified_bool_type () const
+   operator unspecified_bool_type () const BOOST_NOEXCEPT
    {  return m_ptr == 0? 0: &this_type::m_ptr;  }
 
    //!Not operator.
    //!Does not throw
-   bool operator! () const
+   bool operator! () const BOOST_NOEXCEPT
    {  return m_ptr == 0;   }
 
    //!Exchanges the contents of the two smart pointers.
    //!Does not throw
-   void swap(intrusive_ptr & rhs)
+   void swap(intrusive_ptr & rhs) BOOST_NOEXCEPT
    {  ::boost::adl_move_swap(m_ptr, rhs.m_ptr);  }
 
    #if !defined(BOOST_INTERPROCESS_DOXYGEN_INVOKED)
@@ -185,49 +215,49 @@ class intrusive_ptr
 //!Does not throw
 template<class T, class U, class VP> inline
 bool operator==(intrusive_ptr<T, VP> const & a,
-                intrusive_ptr<U, VP> const & b)
+                intrusive_ptr<U, VP> const & b) BOOST_NOEXCEPT
 {  return a.get() == b.get(); }
 
 //!Returns a.get() != b.get().
 //!Does not throw
 template<class T, class U, class VP> inline
 bool operator!=(intrusive_ptr<T, VP> const & a,
-                intrusive_ptr<U, VP> const & b)
+                intrusive_ptr<U, VP> const & b) BOOST_NOEXCEPT
 {  return a.get() != b.get(); }
 
 //!Returns a.get() == b.
 //!Does not throw
 template<class T, class VP> inline
 bool operator==(intrusive_ptr<T, VP> const & a,
-                       const typename intrusive_ptr<T, VP>::pointer &b)
+                       const typename intrusive_ptr<T, VP>::pointer &b) BOOST_NOEXCEPT
 {  return a.get() == b; }
 
 //!Returns a.get() != b.
 //!Does not throw
 template<class T, class VP> inline
 bool operator!=(intrusive_ptr<T, VP> const & a,
-                const typename intrusive_ptr<T, VP>::pointer &b)
+                const typename intrusive_ptr<T, VP>::pointer &b) BOOST_NOEXCEPT
 {  return a.get() != b; }
 
 //!Returns a == b.get().
 //!Does not throw
 template<class T, class VP> inline
 bool operator==(const typename intrusive_ptr<T, VP>::pointer &a,
-                intrusive_ptr<T, VP> const & b)
+                intrusive_ptr<T, VP> const & b) BOOST_NOEXCEPT
 {  return a == b.get(); }
 
 //!Returns a != b.get().
 //!Does not throw
 template<class T, class VP> inline
 bool operator!=(const typename intrusive_ptr<T, VP>::pointer &a,
-                       intrusive_ptr<T, VP> const & b)
+                       intrusive_ptr<T, VP> const & b) BOOST_NOEXCEPT
 {  return a != b.get(); }
 
 //!Returns a.get() < b.get().
 //!Does not throw
 template<class T, class VP> inline
 bool operator<(intrusive_ptr<T, VP> const & a,
-               intrusive_ptr<T, VP> const & b)
+               intrusive_ptr<T, VP> const & b) BOOST_NOEXCEPT
 {
    return std::less<typename intrusive_ptr<T, VP>::pointer>()
       (a.get(), b.get());
@@ -237,34 +267,34 @@ bool operator<(intrusive_ptr<T, VP> const & a,
 //!Does not throw
 template<class T, class VP> inline
 void swap(intrusive_ptr<T, VP> & lhs,
-          intrusive_ptr<T, VP> & rhs)
+          intrusive_ptr<T, VP> & rhs) BOOST_NOEXCEPT
 {  lhs.swap(rhs); }
 
 // operator<<
 template<class E, class T, class Y, class VP>
 inline std::basic_ostream<E, T> & operator<<
-   (std::basic_ostream<E, T> & os, intrusive_ptr<Y, VP> const & p)
+   (std::basic_ostream<E, T> & os, intrusive_ptr<Y, VP> const & p) BOOST_NOEXCEPT
 {  os << p.get(); return os;  }
 
 //!Returns p.get().
 //!Does not throw
 template<class T, class VP>
 inline typename boost::interprocess::intrusive_ptr<T, VP>::pointer
-   to_raw_pointer(intrusive_ptr<T, VP> p)
+   to_raw_pointer(intrusive_ptr<T, VP> p) BOOST_NOEXCEPT
 {  return p.get();   }
 
 /*Emulates static cast operator. Does not throw*/
 /*
 template<class T, class U, class VP>
 inline boost::interprocess::intrusive_ptr<T, VP> static_pointer_cast
-   (boost::interprocess::intrusive_ptr<U, VP> const & p)
+   (boost::interprocess::intrusive_ptr<U, VP> const & p) BOOST_NOEXCEPT
 {  return do_static_cast<U>(p.get());  }
 */
 /*Emulates const cast operator. Does not throw*/
 /*
 template<class T, class U, class VP>
 inline boost::interprocess::intrusive_ptr<T, VP> const_pointer_cast
-   (boost::interprocess::intrusive_ptr<U, VP> const & p)
+   (boost::interprocess::intrusive_ptr<U, VP> const & p) BOOST_NOEXCEPT
 {  return do_const_cast<U>(p.get());   }
 */
 
@@ -272,7 +302,7 @@ inline boost::interprocess::intrusive_ptr<T, VP> const_pointer_cast
 /*
 template<class T, class U, class VP>
 inline boost::interprocess::intrusive_ptr<T, VP> dynamic_pointer_cast
-   (boost::interprocess::intrusive_ptr<U, VP> const & p)
+   (boost::interprocess::intrusive_ptr<U, VP> const & p) BOOST_NOEXCEPT
 {  return do_dynamic_cast<U>(p.get()); }
 */
 
@@ -280,7 +310,7 @@ inline boost::interprocess::intrusive_ptr<T, VP> dynamic_pointer_cast
 /*
 template<class T, class U, class VP>
 inline boost::interprocess::intrusive_ptr<T, VP>reinterpret_pointer_cast
-   (boost::interprocess::intrusive_ptr<U, VP> const & p)
+   (boost::interprocess::intrusive_ptr<U, VP> const & p) BOOST_NOEXCEPT
 {  return do_reinterpret_cast<U>(p.get());   }
 */
 
@@ -292,7 +322,7 @@ inline boost::interprocess::intrusive_ptr<T, VP>reinterpret_pointer_cast
 //!Returns p.get().
 //!Does not throw
 template<class T, class VP>
-inline T *to_raw_pointer(boost::interprocess::intrusive_ptr<T, VP> p)
+inline T *to_raw_pointer(boost::interprocess::intrusive_ptr<T, VP> p) BOOST_NOEXCEPT
 {  return p.get();   }
 #endif
 


### PR DESCRIPTION
… and made its methods noexcept. I hope the BOOST_NOEXCEPT macro is correct for backwards compatibility.

Also added reset() method in line with std::shared_ptr::reset / unique_ptr::reset. In several places of our code I've found this addition useful because the caller had to lock the shared_heap before releasing a reference, so just letting ~intrusive_ptr release the ptr was not correct. 