### PR TITLE
Update VxWorks support

### DIFF
--- a/include/boost/interprocess/detail/atomic.hpp
+++ b/include/boost/interprocess/detail/atomic.hpp
@@ -570,6 +570,60 @@ inline void atomic_write32(volatile boost::uint32_t *mem, boost::uint32_t val)
 }  //namespace ipcdetail{
 }  //namespace interprocess{
 }  //namespace boost{
+#elif defined(__VXWORKS__)
+
+#include <vxAtomicLib.h>
+// VxWorks atomic32_t is not volatile, for some unknown reason
+#define vx_atomic_cast(_i)   (reinterpret_cast< ::atomic32_t *>( const_cast<boost::uint32_t *>(_i)))
+
+namespace boost {
+namespace interprocess {
+namespace ipcdetail{
+
+//! Atomically add 'val' to an boost::uint32_t
+//! "mem": pointer to the object
+//! "val": amount to add
+//! Returns the old value pointed to by mem
+inline boost::uint32_t atomic_add32
+   (volatile boost::uint32_t *mem, boost::uint32_t val)
+{  return ::vxAtomic32Add( vx_atomic_cast(mem), val);   }
+
+//! Atomically increment an apr_uint32_t by 1
+//! "mem": pointer to the object
+//! Returns the old value pointed to by mem
+inline boost::uint32_t atomic_inc32(volatile boost::uint32_t *mem)
+{  return ::vxAtomic32Inc( vx_atomic_cast(mem) );  }
+
+//! Atomically decrement an boost::uint32_t by 1
+//! "mem": pointer to the atomic value
+//! Returns the old value pointed to by mem
+inline boost::uint32_t atomic_dec32(volatile boost::uint32_t *mem)
+{  return ::vxAtomic32Dec( vx_atomic_cast(mem) );   }
+
+//! Atomically read an boost::uint32_t from memory
+inline boost::uint32_t atomic_read32(volatile boost::uint32_t *mem)
+{  return ::vxAtomic32Get( vx_atomic_cast(mem) );  }
+
+//! Compare an boost::uint32_t's value with "cmp".
+//! If they are the same swap the value with "with"
+//! "mem": pointer to the value
+//! "with" what to swap it with
+//! "cmp": the value to compare it to
+//! Returns the old value of *mem
+inline boost::uint32_t atomic_cas32
+   (volatile boost::uint32_t *mem, boost::uint32_t with, boost::uint32_t cmp)
+{  return ::vxAtomic32Cas( vx_atomic_cast(mem), cmp, with);  }
+
+//! Atomically set an boost::uint32_t in memory
+//! "mem": pointer to the object
+//! "param": val value that the object will assume
+inline void atomic_write32(volatile boost::uint32_t *mem, boost::uint32_t val)
+{  ::vxAtomic32Set( vx_atomic_cast(mem), val);  }
+
+
+}  //namespace ipcdetail{
+}  //namespace interprocess{
+}  //namespace boost{
 
 #else
 

--- a/include/boost/interprocess/detail/os_thread_functions.hpp
+++ b/include/boost/interprocess/detail/os_thread_functions.hpp
@@ -52,6 +52,9 @@
 #     include <sys/param.h>
 #     include <sys/sysctl.h>
 #  endif
+#if defined(__VXWORKS__) 
+#include <vxCpuLib.h>
+#endif 
 //According to the article "C/C++ tip: How to measure elapsed real time for benchmarking"
 //Check MacOs first as macOS 10.12 SDK defines both CLOCK_MONOTONIC and
 //CLOCK_MONOTONIC_RAW and no clock_gettime.
@@ -480,6 +483,18 @@ inline unsigned int get_num_cores()
       else{
          return static_cast<unsigned int>(num_cores);
       }
+   #elif defined(__VXWORKS__)
+      cpuset_t set =  ::vxCpuEnabledGet();
+    #ifdef __DCC__
+      int i;
+      for( i = 0; set; ++i)
+          {
+               set &= set -1;
+          }
+      return(i);
+    #else  
+      return (__builtin_popcount(set) );
+    #endif  
    #endif
 }
 

--- a/include/boost/interprocess/detail/workaround.hpp
+++ b/include/boost/interprocess/detail/workaround.hpp
@@ -31,7 +31,7 @@
    //////////////////////////////////////////////////////
    //Check for XSI shared memory objects. They are available in nearly all UNIX platforms
    //////////////////////////////////////////////////////
-   #if !defined(__QNXNTO__) && !defined(__ANDROID__) && !defined(__HAIKU__)
+   #if !defined(__QNXNTO__) && !defined(__ANDROID__) && !defined(__HAIKU__) && !(__VXWORKS__)
       #define BOOST_INTERPROCESS_XSI_SHARED_MEMORY_OBJECTS
    #endif
 


### PR DESCRIPTION
- add CPU count
- provide OS specific atomics (when none with compiler)
- don't use XSI