### PR TITLE
Changed the posix mutex implementation to be robust

### DIFF
--- a/include/boost/interprocess/sync/posix/pthread_helpers.hpp
+++ b/include/boost/interprocess/sync/posix/pthread_helpers.hpp
@@ -41,7 +41,9 @@ namespace ipcdetail{
          if(pthread_mutexattr_init(&m_attr)!=0 ||
             pthread_mutexattr_setpshared(&m_attr, PTHREAD_PROCESS_SHARED)!= 0 ||
              (recursive &&
-              pthread_mutexattr_settype(&m_attr, PTHREAD_MUTEX_RECURSIVE)!= 0 ))
+				 pthread_mutexattr_settype(&m_attr, PTHREAD_MUTEX_RECURSIVE) != 0) ||
+			 pthread_mutexattr_setrobust(&m_attr, PTHREAD_MUTEX_ROBUST) != 0
+			 )
             throw interprocess_exception("pthread_mutexattr_xxxx failed");
       }
 


### PR DESCRIPTION
Added posix robust mutex implementation to allow subsequent mutex lock can grab the lock from previous dead owner. And it also fixed the issue #65.

Hi Reviewers,
 We ran into some issues while we are using boost::interprocess::named_recursive_mutex with posix implementation when the previous owner of the mutex has been dead without releasing the mutex, so all others which are waiting for the same mutex will be blocked forever. And that's why I added this fix in posix mutex implementation to avoid this issue.