### PR TITLE
Changed to use posix robust mutex

### DIFF
--- a/include/boost/interprocess/sync/posix/pthread_helpers.hpp
+++ b/include/boost/interprocess/sync/posix/pthread_helpers.hpp
@@ -41,8 +41,9 @@ namespace ipcdetail{
          if(pthread_mutexattr_init(&m_attr)!=0 ||
             pthread_mutexattr_setpshared(&m_attr, PTHREAD_PROCESS_SHARED)!= 0 ||
              (recursive &&
-              pthread_mutexattr_settype(&m_attr, PTHREAD_MUTEX_RECURSIVE)!= 0 ))
-            throw interprocess_exception("pthread_mutexattr_xxxx failed");
+			  pthread_mutexattr_settype(&m_attr, PTHREAD_MUTEX_RECURSIVE) != 0 ) ||
+			pthread_mutexattr_setrobust(&m_attr, PTHREAD_MUTEX_ROBUST) != 0 )
+			 throw interprocess_exception("pthread_mutexattr_xxxx failed");
       }
 
       //!Destructor

--- a/include/boost/interprocess/sync/posix/recursive_mutex.hpp
+++ b/include/boost/interprocess/sync/posix/recursive_mutex.hpp
@@ -89,7 +89,10 @@ inline void posix_recursive_mutex::lock()
 {
    int res = pthread_mutex_lock(&m_mut);
    if (res == EOWNERDEAD)
-      pthread_mutex_consistent(&m_mut);
+   {
+	  pthread_mutex_consistent(&m_mut);
+	  throw interprocess_exception(owner_dead_error);
+   }
    else if (res != 0)
       throw lock_exception();
 }
@@ -98,10 +101,13 @@ inline bool posix_recursive_mutex::try_lock()
 {
    int res = pthread_mutex_trylock(&m_mut);
    if (res == EOWNERDEAD)
-      pthread_mutex_consistent(&m_mut);
+   {
+	  pthread_mutex_consistent(&m_mut);
+	  throw interprocess_exception(owner_dead_error);
+   }
    else if (!(res == 0 || res == EBUSY))
       throw lock_exception();
-   return (res == 0 || res == EOWNERDEAD);
+   return (res == 0);
 }
 
 inline bool posix_recursive_mutex::timed_lock(const boost::posix_time::ptime &abs_time)
@@ -116,10 +122,13 @@ inline bool posix_recursive_mutex::timed_lock(const boost::posix_time::ptime &ab
    timespec ts = ptime_to_timespec(abs_time);
    int res = pthread_mutex_timedlock(&m_mut, &ts);
    if (res == EOWNERDEAD)
-      pthread_mutex_consistent(&m_mut);
+   {
+	  pthread_mutex_consistent(&m_mut);
+	  throw interprocess_exception(owner_dead_error);
+   }
    else if (res != 0 && res != ETIMEDOUT)
 	  throw lock_exception();
-   return (res == 0 || res == EOWNERDEAD);
+   return (res == 0);
 
    #else //BOOST_INTERPROCESS_POSIX_TIMEOUTS
 

--- a/include/boost/interprocess/sync/posix/recursive_mutex.hpp
+++ b/include/boost/interprocess/sync/posix/recursive_mutex.hpp
@@ -87,16 +87,21 @@ inline posix_recursive_mutex::~posix_recursive_mutex()
 
 inline void posix_recursive_mutex::lock()
 {
-   if (pthread_mutex_lock(&m_mut) != 0)
+   int res = pthread_mutex_lock(&m_mut);
+   if (res == EOWNERDEAD)
+      pthread_mutex_consistent(&m_mut);
+   else if (res != 0)
       throw lock_exception();
 }
 
 inline bool posix_recursive_mutex::try_lock()
 {
    int res = pthread_mutex_trylock(&m_mut);
-   if (!(res == 0 || res == EBUSY))
+   if (res == EOWNERDEAD)
+      pthread_mutex_consistent(&m_mut);
+   else if (!(res == 0 || res == EBUSY))
       throw lock_exception();
-   return res == 0;
+   return (res == 0 || res == EOWNERDEAD);
 }
 
 inline bool posix_recursive_mutex::timed_lock(const boost::posix_time::ptime &abs_time)
@@ -110,9 +115,11 @@ inline bool posix_recursive_mutex::timed_lock(const boost::posix_time::ptime &ab
 
    timespec ts = ptime_to_timespec(abs_time);
    int res = pthread_mutex_timedlock(&m_mut, &ts);
-   if (res != 0 && res != ETIMEDOUT)
-      throw lock_exception();
-   return res == 0;
+   if (res == EOWNERDEAD)
+      pthread_mutex_consistent(&m_mut);
+   else if (res != 0 && res != ETIMEDOUT)
+	  throw lock_exception();
+   return (res == 0 || res == EOWNERDEAD);
 
    #else //BOOST_INTERPROCESS_POSIX_TIMEOUTS
 


### PR DESCRIPTION
Changed to use posix robust mutex to allow subsequent mutex lock can grab the lock from previous dead owner to void deadlock. And it also fixed the issue #65.

Hi Reviewers,
We ran into some issues while we are using boost::interprocess::named_recursive_mutex with posix implementation when the previous owner of the mutex has been dead without releasing the mutex, so all others which are waiting for the same mutex will be blocked forever. And that's why I added this fix in posix mutex implementation to avoid this issue.