### PR TITLE
Fix deadlock in named_condition::notify_one

### DIFF
--- a/include/boost/interprocess/sync/spin/mutex.hpp
+++ b/include/boost/interprocess/sync/spin/mutex.hpp
@@ -64,7 +64,21 @@ inline spin_mutex::~spin_mutex()
 }
 
 inline void spin_mutex::lock(void)
-{  return ipcdetail::try_based_lock(*this); }
+{
+#ifdef BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING
+	boost::posix_time::ptime wait_time
+		= microsec_clock::universal_time()
+		+ boost::posix_time::milliseconds(BOOST_INTERPROCESS_TIMEOUT_WHEN_LOCKING_DURATION_MS);
+	if (!timed_lock(wait_time))
+	{
+		throw interprocess_exception(timeout_when_locking_error
+			, "Interprocess mutex timeout when locking. Possible deadlock: "
+			"owner died without unlocking?");
+	}
+#else
+   return ipcdetail::try_based_lock(*this);
+#endif
+}
 
 inline bool spin_mutex::try_lock(void)
 {


### PR DESCRIPTION
Avoid deadlock in named_condition::notify_one when BOOST_INTERPROCESS_ENABLE_TIMEOUT_WHEN_LOCKING is defined

Fixes issue #69 