### PR TITLE
Add BOOST_INTERPROCESS_FORCE_NATIVE_EMULATION option

### DIFF
--- a/include/boost/interprocess/detail/workaround.hpp
+++ b/include/boost/interprocess/detail/workaround.hpp
@@ -21,7 +21,9 @@
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
    #define BOOST_INTERPROCESS_WINDOWS
+#if !defined(BOOST_INTERPROCESS_NO_FORCE_GENERIC_EMULATION)
    #define BOOST_INTERPROCESS_FORCE_GENERIC_EMULATION
+#endif
    #define BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME
    //Define this to connect with shared memory created with versions < 1.54
    //#define BOOST_INTERPROCESS_BOOTSTAMP_IS_LASTBOOTUPTIME


### PR DESCRIPTION
Addresses #43.

This adds an option `BOOST_INTERPROCESS_NO_FORCE_GENERIC_EMULATION` to disable the forced emulation on Windows, but without the need to manually change the headers or other hacks.
The performance difference between emulation and non-emulation is 1ms vs 50us using `interprocess_condition` on my machine.

Another option would be to remove the `BOOST_INTERPROCESS_FORCE_GENERIC_EMULATION` define all together, but I think opting into this change would be safer especially since the Windows IPC is apparently experimental and this would break the ABI between versions.