### PR TITLE
Correct references for named_condition_any

### DIFF
--- a/doc/interprocess.qbk
+++ b/doc/interprocess.qbk
@@ -1605,7 +1605,7 @@ Boost.Interprocess offers the following condition types:
 
    #include <boost/interprocess/sync/named_condition_any.hpp>
 
-* [classref boost::interprocess::named_condition named_condition]: A named
+* [classref boost::interprocess::named_condition_any named_condition_any]: A named
   condition variable to be used with any lock type.
 
 Named conditions are similar to anonymous conditions, but they are used in


### PR DESCRIPTION
References for named_condition_any point to named_condition now corrected to named_condition_any.