### PR TITLE
Correct MSVC compilation warning

### DIFF
--- a/include/boost/interprocess/streams/bufferstream.hpp
+++ b/include/boost/interprocess/streams/bufferstream.hpp
@@ -132,7 +132,7 @@ class basic_bufferbuf
             }
             else if(m_mode & std::ios_base::out) {
                this->gbump(-1);
-               *this->gptr() = c;
+               *this->gptr() = CharTraits::to_char_type(c);
                return c;
             }
             else


### PR DESCRIPTION
boost/interprocess/streams/bufferstream.hpp(135): warning C4242: '=': conversion from 'int' to '_Elem', possible loss of data
        with
        [
            _Elem=char
        ]