### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/interprocess/detail/os_file_functions.hpp
+++ b/include/boost/interprocess/detail/os_file_functions.hpp
@@ -24,9 +24,9 @@
 #include <boost/interprocess/errors.hpp>
 #include <boost/interprocess/permissions.hpp>
 
-#include <string>
-#include <limits>
 #include <climits>
+#include <limits>
+#include <string>
 #include <boost/move/detail/type_traits.hpp> //make_unsigned
 
 #if defined (BOOST_INTERPROCESS_WINDOWS)
@@ -37,9 +37,9 @@
 #     include <unistd.h>
 #     include <sys/types.h>
 #     include <sys/stat.h>
-#     include <errno.h>
-#     include <cstdio>
 #     include <dirent.h>
+#     include <cerrno>
+#     include <cstdio>
 #     if 0
 #        include <sys/file.h>
 #     endif
@@ -457,7 +457,7 @@ inline file_handle_t create_or_open_file
    int ret = -1;
    //We need a loop to change permissions correctly using fchmod, since
    //with "O_CREAT only" ::open we don't know if we've created or opened the file.
-   while(1){
+   while(true){
       ret = ::open(name, ((int)mode) | O_EXCL | O_CREAT, perm.get_permissions());
       if(ret >= 0){
          ::fchmod(ret, perm.get_permissions());

--- a/include/boost/interprocess/errors.hpp
+++ b/include/boost/interprocess/errors.hpp
@@ -34,14 +34,13 @@
 
 #include <boost/interprocess/detail/config_begin.hpp>
 #include <boost/interprocess/detail/workaround.hpp>
-#include <stdarg.h>
 #include <string>
 
 #if defined (BOOST_INTERPROCESS_WINDOWS)
 #  include <boost/interprocess/detail/win32_api.hpp>
 #else
 #  ifdef BOOST_HAS_UNISTD_H
-#    include <errno.h>        //Errors
+#    include <cerrno>         //Errors
 #    include <cstring>        //strerror
 #  else  //ifdef BOOST_HAS_UNISTD_H
 #    error Unknown platform

--- a/include/boost/interprocess/exceptions.hpp
+++ b/include/boost/interprocess/exceptions.hpp
@@ -60,9 +60,9 @@ class BOOST_SYMBOL_VISIBLE interprocess_exception : public std::exception
       catch(...){}
    }
 
-   virtual ~interprocess_exception() BOOST_NOEXCEPT_OR_NOTHROW {}
+   ~interprocess_exception() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {}
 
-   virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW
+   const char * what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
    {  return m_str.c_str();  }
 
    native_error_t get_native_error()const { return m_err.get_native_error(); }
@@ -86,7 +86,7 @@ class BOOST_SYMBOL_VISIBLE lock_exception : public interprocess_exception
       :  interprocess_exception(lock_error)
    {}
 
-   virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW
+   const char* what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
    {  return "boost::interprocess::lock_exception";  }
 };
 
@@ -96,9 +96,10 @@ class BOOST_SYMBOL_VISIBLE lock_exception : public interprocess_exception
 class BOOST_SYMBOL_VISIBLE bad_alloc : public interprocess_exception
 {
  public:
-   bad_alloc() : interprocess_exception("::boost::interprocess::bad_alloc"){}
-   virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW
-      {  return "boost::interprocess::bad_alloc";  }
+   bad_alloc() : interprocess_exception("::boost::interprocess::bad_alloc") {}
+
+   const char* what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
+   {  return "boost::interprocess::bad_alloc";  }
 };
 
 }  // namespace interprocess {

--- a/include/boost/interprocess/shared_memory_object.hpp
+++ b/include/boost/interprocess/shared_memory_object.hpp
@@ -328,7 +328,7 @@ inline bool shared_memory_object::priv_open_or_create
       {
          //We need a create/open loop to change permissions correctly using fchmod, since
          //with "O_CREAT" only we don't know if we've created or opened the shm.
-         while(1){
+         while(true){
             //Try to create shared memory
             m_handle = shm_open(m_filename.c_str(), oflag | (O_CREAT | O_EXCL), unix_perm);
             //If successful change real permissions


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Also fix Clang-tidy modernize-deprecated-headers and modernize-use-bool-literals warnings.
Alphabetical order of STL headers.