### PR TITLE
Fix mingw compile error

### DIFF
--- a/include/boost/interprocess/detail/win32_api.hpp
+++ b/include/boost/interprocess/detail/win32_api.hpp
@@ -716,9 +716,9 @@ class interprocess_all_access_security
    interprocess_all_access_security()
       : initialized(false)
    {
-      if(!InitializeSecurityDescriptor(&sd, security_descriptor_revision))
+      if(!boost::winapi::InitializeSecurityDescriptor(&sd, security_descriptor_revision))
          return;
-      if(!::SetSecurityDescriptorDacl(&sd, true, 0, false))
+      if(!boost::winapi::SetSecurityDescriptorDacl(&sd, true, 0, false))
          return;
       sa.lpSecurityDescriptor = &sd;
       sa.nLength = sizeof(interprocess_security_attributes);

--- a/include/boost/interprocess/detail/win32_api.hpp
+++ b/include/boost/interprocess/detail/win32_api.hpp
@@ -723,7 +723,7 @@ class interprocess_all_access_security
       sa.lpSecurityDescriptor = &sd;
       sa.nLength = sizeof(interprocess_security_attributes);
       sa.bInheritHandle = false;
-      initialized = false;
+      initialized = true;
    }
 
    interprocess_security_attributes *get_attributes()


### PR DESCRIPTION
MinGW has nonstandard definition of `PSECURITY_DESCRIPTOR`, which requires a cast when calling WinAPI functions `InitializeSecurityDescriptor` and `SetSecurityDescriptorDacl`. This is done by Boost.WinAPI wrapper functions.

Fixes https://github.com/boostorg/interprocess/issues/118.

Also, fixed the `initialized` flag not being set correctly after `interprocess_all_access_security` initialization completes.
