### PR TITLE
Fix trivial typo in comment for example for message queue

### DIFF
--- a/example/comp_doc_message_queueB.cpp
+++ b/example/comp_doc_message_queueB.cpp
@@ -20,7 +20,7 @@ int main ()
    try{
       //Open a message queue.
       message_queue mq
-         (open_only        //only create
+         (open_only        //only open
          ,"message_queue"  //name
          );
 


### PR DESCRIPTION
Fix comment in accordance with the original type description from the: boost/interprocess/creation_tags.hpp.