### PR TITLE
properly initilize enable_shared_from_this if the type is const

### DIFF
--- a/include/boost/interprocess/smart_ptr/shared_ptr.hpp
+++ b/include/boost/interprocess/smart_ptr/shared_ptr.hpp
@@ -56,7 +56,7 @@ namespace ipcdetail{
 template<class T, class VoidAllocator, class Deleter>
 inline void sp_enable_shared_from_this
   (shared_count<T, VoidAllocator, Deleter> const & pn
-  ,enable_shared_from_this<T, VoidAllocator, Deleter> *pe
+  ,enable_shared_from_this<T, VoidAllocator, Deleter> const*pe
   ,T *ptr)
 
 {

--- a/test/shared_ptr_test.cpp
+++ b/test/shared_ptr_test.cpp
@@ -596,6 +596,32 @@ void test_alias()
    shared_memory_object::remove(process_name.c_str());
 }
 
+
+struct std_deleter
+{
+   typedef const void* pointer;
+
+   void operator()(const void* p) const;
+};
+
+struct shared_from_this_tester: enable_shared_from_this<
+    const shared_from_this_tester, std::allocator<void>, std_deleter
+> {};
+
+void std_deleter::operator()(const void* p) const
+{
+    delete static_cast<const shared_from_this_tester*>(p);
+}
+
+
+void test_const_shared_from_this()
+{
+    shared_ptr<const shared_from_this_tester, std::allocator<void>, std_deleter> cptr(
+        new shared_from_this_tester()
+    );
+    BOOST_TEST( cptr->shared_from_this().get() == cptr.get() );
+}
+
 int main()
 {
    if(0 != simple_test())
@@ -608,5 +634,6 @@ int main()
       return 1;
 
    test_alias();
+   test_const_shared_from_this();
 }
 


### PR DESCRIPTION
Without `const` the new test fails with the following error:
```
terminate called after throwing an instance of 'boost::interprocess::bad_weak_ptr'
  what():  boost::interprocess::bad_weak_ptr
Aborted (core dumped)
```