### PR TITLE
Fix missing sys/stat.h include on musl-based systems

### DIFF
--- a/include/boost/interprocess/permissions.hpp
+++ b/include/boost/interprocess/permissions.hpp
@@ -29,6 +29,10 @@
 
 #include <boost/interprocess/detail/win32_api.hpp>
 
+#else
+
+#include <sys/stat.h>
+
 #endif
 
 #endif   //#ifndef BOOST_INTERPROCESS_DOXYGEN_INVOKED


### PR DESCRIPTION
Boost 1.78.0 fails to build on musl-based systems because musl does
not include sys/stat.h by default.

Fixes #161 ("Boost compiler error")