### PR TITLE
Fix compilation error after disabling RTTI support

### DIFF
--- a/include/boost/interprocess/detail/cast_tags.hpp
+++ b/include/boost/interprocess/detail/cast_tags.hpp
@@ -21,9 +21,12 @@
 
 namespace boost { namespace interprocess { namespace ipcdetail {
 
+#if !defined(BOOST_NO_RTTI)
+struct dynamic_cast_tag {};
+#endif //#if !defined(BOOST_NO_RTTI)
+
 struct static_cast_tag {};
 struct const_cast_tag {};
-struct dynamic_cast_tag {};
 struct reinterpret_cast_tag {};
 
 }}}  //namespace boost { namespace interprocess { namespace ipcdetail {

--- a/include/boost/interprocess/detail/in_place_interface.hpp
+++ b/include/boost/interprocess/detail/in_place_interface.hpp
@@ -23,7 +23,12 @@
 #include <boost/interprocess/detail/workaround.hpp>
 #include <boost/interprocess/detail/type_traits.hpp>
 #include <boost/container/detail/type_traits.hpp>  //alignment_of, aligned_storage
-#include <typeinfo>  //typeid
+
+#if defined(BOOST_NO_RTTI)
+#  include <boost/type_index.hpp>
+#else
+#  include <typeinfo> //typeid
+#endif
 
 //!\file
 //!Describes an abstract interface for placement construction and destruction.
@@ -51,7 +56,15 @@ template<class T>
 struct placement_destroy :  public in_place_interface
 {
    placement_destroy()
-      :  in_place_interface(::boost::container::dtl::alignment_of<T>::value, sizeof(T), typeid(T).name())
+   :  in_place_interface(
+      ::boost::container::dtl::alignment_of<T>::value, 
+      sizeof(T), 
+#if defined(BOOST_NO_RTTI)
+      boost::typeindex::type_id<T>().pretty_name(),
+#else
+      typeid(T).name(),
+#endif //#if defined(BOOST_NO_RTTI)
+      )
    {}
 
    virtual void destroy_n(void *mem, std::size_t num, std::size_t &destroyed) BOOST_OVERRIDE

--- a/include/boost/interprocess/detail/intermodule_singleton_common.hpp
+++ b/include/boost/interprocess/detail/intermodule_singleton_common.hpp
@@ -403,17 +403,31 @@ class intermodule_singleton_impl
       void operator()()
       {
          ref_count_ptr *rcount = intermodule_singleton_helpers::thread_safe_global_map_dependant
+#if defined(BOOST_NO_RTTI)
+            <ThreadSafeGlobalMap>::find(m_map, boost::typeindex::type_id<C>().pretty_name());
+#else
             <ThreadSafeGlobalMap>::find(m_map, typeid(C).name());
+#endif //#if defined(BOOST_NO_RTTI)
          if(!rcount){
             C *p = new C;
-            BOOST_TRY{
+            BOOST_TRY
+            {
                ref_count_ptr val(p, 0u);
                rcount = intermodule_singleton_helpers::thread_safe_global_map_dependant
+#if defined(BOOST_NO_RTTI)
+                           <ThreadSafeGlobalMap>::insert(m_map, boost::typeindex::type_id<C>().pretty_name(), val);
+#else
                            <ThreadSafeGlobalMap>::insert(m_map, typeid(C).name(), val);
+#endif //#if defined(BOOST_NO_RTTI)
             }
-            BOOST_CATCH(...){
+            BOOST_CATCH(...)
+            {
                intermodule_singleton_helpers::thread_safe_global_map_dependant
+#if defined(BOOST_NO_RTTI)
+                           <ThreadSafeGlobalMap>::erase(m_map, boost::typeindex::type_id<C>().pretty_name());
+#else
                            <ThreadSafeGlobalMap>::erase(m_map, typeid(C).name());
+#endif //#if defined(BOOST_NO_RTTI)
                delete p;
                BOOST_RETHROW
             } BOOST_CATCH_END
@@ -443,7 +457,11 @@ class intermodule_singleton_impl
       void operator()()
       {
          ref_count_ptr *rcount = intermodule_singleton_helpers::thread_safe_global_map_dependant
+#if defined(BOOST_NO_RTTI)
+            <ThreadSafeGlobalMap>::find(m_map, boost::typeindex::type_id<C>().pretty_name());
+#else
             <ThreadSafeGlobalMap>::find(m_map, typeid(C).name());
+#endif //#if defined(BOOST_NO_RTTI)
             //The object must exist
          BOOST_ASSERT(rcount);
          BOOST_ASSERT(rcount->singleton_ref_count > 0);
@@ -454,7 +472,11 @@ class intermodule_singleton_impl
             C *pc = static_cast<C*>(rcount->ptr);
             //Now destroy map entry
             bool destroyed = intermodule_singleton_helpers::thread_safe_global_map_dependant
+#if defined(BOOST_NO_RTTI)
+                        <ThreadSafeGlobalMap>::erase(m_map, boost::typeindex::type_id<C>().pretty_name());
+#else
                         <ThreadSafeGlobalMap>::erase(m_map, typeid(C).name());
+#endif //#if defined(BOOST_NO_RTTI)
             (void)destroyed;  BOOST_ASSERT(destroyed == true);
             delete pc;
          }

--- a/include/boost/interprocess/detail/intersegment_ptr.hpp
+++ b/include/boost/interprocess/detail/intersegment_ptr.hpp
@@ -648,11 +648,15 @@ class intersegment_ptr : public flat_map_intersegment<interprocess_mutex>
    intersegment_ptr(const intersegment_ptr<U> &r, ipcdetail::const_cast_tag)
    {  base_t::set_from_pointer(const_cast<T*>(r.get())); }
 
+#if !defined(BOOST_NO_RTTI)
+
    //!Emulates dynamic_cast operator.
    //!Never throws.
    template<class U>
    intersegment_ptr(const intersegment_ptr<U> &r, ipcdetail::dynamic_cast_tag)
    {  base_t::set_from_pointer(dynamic_cast<T*>(r.get())); }
+   
+#endif //#if !defined(BOOST_NO_RTTI)
 
    //!Emulates reinterpret_cast operator.
    //!Never throws.
@@ -887,11 +891,15 @@ template<class T, class U> inline
 boost::interprocess::intersegment_ptr<T> const_pointer_cast(const boost::interprocess::intersegment_ptr<U> &r)
 {  return boost::interprocess::intersegment_ptr<T>(r, boost::interprocess::ipcdetail::const_cast_tag());  }
 
+#if !defined(BOOST_NO_RTTI)
+
 //!Simulation of dynamic_cast between pointers.
 //!Never throws.
 template<class T, class U> inline
 boost::interprocess::intersegment_ptr<T> dynamic_pointer_cast(const boost::interprocess::intersegment_ptr<U> &r)
 {  return boost::interprocess::intersegment_ptr<T>(r, boost::interprocess::ipcdetail::dynamic_cast_tag());  }
+
+#endif //#if !defined(BOOST_NO_RTTI)
 
 //!Simulation of reinterpret_cast between pointers.
 //!Never throws.

--- a/include/boost/interprocess/offset_ptr.hpp
+++ b/include/boost/interprocess/offset_ptr.hpp
@@ -329,12 +329,16 @@ class offset_ptr
       : internal(ipcdetail::offset_ptr_to_offset<OffsetType>(const_cast<PointedType*>(r.get()), this))
    {}
 
+#if !defined(BOOST_NO_RTTI)
+
    //!Emulates dynamic_cast operator.
    //!Never throws.
    template<class T2, class P2, class O2, std::size_t A2>
    BOOST_INTERPROCESS_FORCEINLINE offset_ptr(const offset_ptr<T2, P2, O2, A2> & r, ipcdetail::dynamic_cast_tag) BOOST_NOEXCEPT
       : internal(ipcdetail::offset_ptr_to_offset<OffsetType>(dynamic_cast<PointedType*>(r.get()), this))
    {}
+   
+#endif //#if !defined(BOOST_NO_RTTI)
 
    //!Emulates reinterpret_cast operator.
    //!Never throws.
@@ -628,6 +632,8 @@ BOOST_INTERPROCESS_FORCEINLINE boost::interprocess::offset_ptr<T1, P1, O1, A1>
             (r, boost::interprocess::ipcdetail::const_cast_tag());
 }
 
+#if !defined(BOOST_NO_RTTI)
+
 //!Simulation of dynamic_cast between pointers. Never throws.
 template<class T1, class P1, class O1, std::size_t A1, class T2, class P2, class O2, std::size_t A2>
 BOOST_INTERPROCESS_FORCEINLINE boost::interprocess::offset_ptr<T1, P1, O1, A1>
@@ -636,6 +642,8 @@ BOOST_INTERPROCESS_FORCEINLINE boost::interprocess::offset_ptr<T1, P1, O1, A1>
    return boost::interprocess::offset_ptr<T1, P1, O1, A1>
             (r, boost::interprocess::ipcdetail::dynamic_cast_tag());
 }
+
+#endif //#if !defined(BOOST_NO_RTTI)
 
 //!Simulation of reinterpret_cast between pointers. Never throws.
 template<class T1, class P1, class O1, std::size_t A1, class T2, class P2, class O2, std::size_t A2>

--- a/include/boost/interprocess/smart_ptr/shared_ptr.hpp
+++ b/include/boost/interprocess/smart_ptr/shared_ptr.hpp
@@ -192,6 +192,8 @@ class shared_ptr
              , r.m_pn)
    {}
 
+   #if !defined(BOOST_NO_RTTI)
+
    template<class Y>
    shared_ptr(shared_ptr<Y, VoidAllocator, Deleter> const & r, ipcdetail::dynamic_cast_tag)
       :  m_pn( pointer(dynamic_cast<T*>(ipcdetail::to_raw_pointer(r.m_pn.to_raw_pointer())))
@@ -201,6 +203,8 @@ class shared_ptr
          m_pn = ipcdetail::shared_count<T, VoidAllocator, Deleter>();
       }
    }
+   #endif   //#if !defined(BOOST_NO_RTTI)
+
    #endif   //#ifndef BOOST_INTERPROCESS_DOXYGEN_INVOKED
 
    //!Equivalent to shared_ptr(r).swap(*this).
@@ -348,9 +352,13 @@ template<class T, class VoidAllocator, class Deleter, class U> inline
 shared_ptr<T, VoidAllocator, Deleter> const_pointer_cast(shared_ptr<U, VoidAllocator, Deleter> const & r)
 {  return shared_ptr<T, VoidAllocator, Deleter>(r, ipcdetail::const_cast_tag()); }
 
+#if !defined(BOOST_NO_RTTI)
+
 template<class T, class VoidAllocator, class Deleter, class U> inline
 shared_ptr<T, VoidAllocator, Deleter> dynamic_pointer_cast(shared_ptr<U, VoidAllocator, Deleter> const & r)
 {  return shared_ptr<T, VoidAllocator, Deleter>(r, ipcdetail::dynamic_cast_tag());  }
+
+#endif //#if !defined(BOOST_NO_RTTI)
 
 // to_raw_pointer() enables boost::mem_fn to recognize shared_ptr
 template<class T, class VoidAllocator, class Deleter> inline


### PR DESCRIPTION
I tried to fix that issue by adding `BOOST_NO_RTTI ` preprocessor definition and type_index solution of Boost itself which I created PR #164.

In my opinion, `dynamic_cast_tag` struct must be supported if only RTTI is not disabled via this flag. Because of that reason, I just wrapped up with `BOOST_NO_RTTI ` preprocessor where it is used. If you disagree with that, you can offer another solution for that.

I do not edit any documentation or test code without confirmation, please review this and let me know which parts need to be changed on documentation and test codes.

Thanks in advance. 