### PR TITLE
Fixing windows_shared_memory::get_name()

### DIFF
--- a/include/boost/interprocess/windows_shared_memory.hpp
+++ b/include/boost/interprocess/windows_shared_memory.hpp
@@ -194,6 +194,13 @@ template <class CharT>
 inline bool windows_shared_memory::priv_open_or_create
    (ipcdetail::create_enum_t type, const CharT *filename, mode_t mode, std::size_t size, const permissions& perm)
 {
+   if (filename){
+      m_name = filename;
+   }
+   else{
+      m_name = "";
+   }
+
    unsigned long protection = 0;
    unsigned long map_access = 0;
 


### PR DESCRIPTION
Fixes issue #153.

Restores the original behavior (pre 140b50efb3281fa3898f3a4cf939cfbda174718f).
If `filename` is provided as a wide string, then `get_name()` will return an unspecified pointer.