### PR TITLE
remove redundent assertion alignment check to avoid exiting the function without releasing scoped mutex

### DIFF
--- a/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
+++ b/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
@@ -645,7 +645,6 @@ bool rbtree_best_fit<MutexFamily, VoidPointer, MemAlignment>::
    //Iterate through all blocks obtaining their size
    for(; ib != ie; ++ib){
       free_memory += (size_type)ib->m_size*Alignment;
-      algo_impl_t::assert_alignment(&*ib);
       if(!algo_impl_t::check_alignment(&*ib))
          return false;
    }


### PR DESCRIPTION
The assertion in the ```check_sanity()``` function causes the function to crash without releasing the ```shared mutex```.
The assertion is redundant due to ```alignment check``` in the following lines that returns ```false``` in case of failure and releases the ```shared mutex```.
PR for [Issue 177](https://github.com/boostorg/interprocess/issues/177)