### PR TITLE
Fix: emscripten doesn't support shm

### DIFF
--- a/include/boost/interprocess/detail/workaround.hpp
+++ b/include/boost/interprocess/detail/workaround.hpp
@@ -37,7 +37,7 @@
    //////////////////////////////////////////////////////
    //Check for XSI shared memory objects. They are available in nearly all UNIX platforms
    //////////////////////////////////////////////////////
-   #if !defined(__QNXNTO__) && !defined(__ANDROID__) && !defined(__HAIKU__) && !(__VXWORKS__)
+   #if !defined(__QNXNTO__) && !defined(__ANDROID__) && !defined(__HAIKU__) && !(__VXWORKS__) && !(__EMSCRIPTEN__)
       #define BOOST_INTERPROCESS_XSI_SHARED_MEMORY_OBJECTS
    #endif
 


### PR DESCRIPTION
I met an error
```
wasm-ld: error: build/sysroot/usr/local/lib/librime.a(mapped_file.cc.o): undefined symbol: shmdt
```
From https://stackoverflow.com/questions/60285563/shared-memory-sys-shm-h-with-emscripten it seems emscripten doesn't support shm.
I applied this patch so it linked successfully.