### PR TITLE
add positive infinity test case

### DIFF
--- a/test/mutex_test_template.hpp
+++ b/test/mutex_test_template.hpp
@@ -105,10 +105,15 @@ struct test_timedlock
 
       // Test the lock's constructors.
       {
-         // Construct and initialize an ptime for a fast time out.
+         // Construct and initialize a ptime for a fast time out.
          timed_lock_type lock(interprocess_mutex, ptime_delay(1*BaseSeconds));
          BOOST_INTERPROCESS_CHECK(lock ? true : false);
       }
+      {
+         // Construct and initialize positive infinity.
+         timed_lock_type lock(interprocess_mutex, boost::posix_time::pos_infin);
+         BOOST_INTERPROCESS_CHECK(lock ? true : false);
+      } 
       {
          timed_lock_type lock(interprocess_mutex, boost::interprocess::defer_lock);
          BOOST_INTERPROCESS_CHECK(!lock);


### PR DESCRIPTION
In my recent effort to upgrade from boost 1.69 I discovered a change of behavior after [the commit 30d5005ac627b36c122e69c86cf518aaaadd92ab](https://github.com/boostorg/interprocess/commit/30d5005ac627b36c122e69c86cf518aaaadd92ab). Is my expectation of `boost::posix_time::pos_infin` to pass the check in [semaphore_wrapper](https://github.com/boostorg/interprocess/blob/develop/include/boost/interprocess/sync/posix/semaphore_wrapper.hpp#L220) incorrect?

One example of a public library relying on `pos_infin` [Fast-DDS](https://github.com/eProsima/Fast-DDS/blob/v2.9.0/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp#L372)

Attempts to build the library with a recent boost results in:

```
boost/interprocess/sync/posix/semaphore_wrapper.hpp:226:21: error: no matching function for call to 'timepoint_to_timespec'
   timespec tspec = timepoint_to_timespec(abs_time);
                    ^~~~~~~~~~~~~~~~~~~~~
boost/interprocess/sync/posix/semaphore.hpp:55:14: note: in instantiation of function template specialization 'boost::interprocess::ipcdetail::semaphore_timed_wait<boost::date_time::special_values>' requested here
   {  return semaphore_timed_wait(&m_sem, abs_time); }
             ^
boost/interprocess/sync/interprocess_semaphore.hpp:133:16: note: in instantiation of function template specialization 'boost::interprocess::ipcdetail::posix_semaphore::timed_wait<boost::date_time::special_values>' requested here
{ return m_sem.timed_wait(abs_time); }
               ^
Fast-DDS-2.9.0/src/cpp/utils/shared_memory/RobustInterprocessCondition.hpp:372:45: note: in instantiation of function template specialization 'boost::interprocess::interprocess_semaphore::timed_wait<boost::date_time::special_values>' requested here
            semaphores_pool_[sem_index].sem.timed_wait(boost::posix_time::pos_infin);
                                            ^
boost/interprocess/sync/posix/timepoint_to_timespec.hpp:50:17: note: candidate function not viable: no known conversion from 'const boost::date_time::special_values' to 'const boost::interprocess::ipcdetail::ustime' for 1st argument
inline timespec timepoint_to_timespec (const ustime &tm)
                ^
boost/interprocess/sync/posix/timepoint_to_timespec.hpp:33:17: note: candidate template ignored: substitution failure [with TimePoint = boost::date_time::special_values]: no type named 'type' in 'boost::interprocess::ipcdetail::enable_if_ptime<boost::date_time::special_values>'
inline timespec timepoint_to_timespec ( const TimePoint &tm
                ^
boost/interprocess/sync/posix/timepoint_to_timespec.hpp:59:17: note: candidate template ignored: substitution failure [with TimePoint = boost::date_time::special_values]: no type named 'type' in 'boost::interprocess::ipcdetail::enable_if_time_point<boost::date_time::special_values>'
inline timespec timepoint_to_timespec ( const TimePoint &tm
                ^
```

I attempted to add a repro case. What would be the best way to approach a fix? Thanks!

