### PR TITLE
Fix Windows RTC issue

### DIFF
--- a/include/boost/interprocess/detail/windows_intermodule_singleton.hpp
+++ b/include/boost/interprocess/detail/windows_intermodule_singleton.hpp
@@ -115,7 +115,7 @@ class windows_semaphore_based_map
          caster.addr = m;
          BOOST_ASSERT((caster.addr_uint64 & boost::uint64_t(3)) == 0);
          max_count = boost::uint32_t(caster.addr_uint64 >> 32);
-         initial_count = boost::uint32_t(caster.addr_uint64);
+         initial_count = boost::uint32_t(caster.addr_uint64 & boost::uint64_t(0x00000000FFFFFFFF));
          initial_count = initial_count/4;
          //Make sure top two bits are zero
          BOOST_ASSERT((max_count & boost::uint32_t(0xC0000000)) == 0);


### PR DESCRIPTION
I reproduced [this](https://github.com/cmazakas/unordered/actions/runs/9035399323/job/24830087065#step:6:1478) failing CI run of Boost.Unordered locally, and found that it gave me a pop-up coming from Boost.Interprocess.
![image](https://github.com/boostorg/interprocess/assets/10316270/b057978d-a484-45d5-b6c7-cccf35eb042c)
After the change in this PR, the issue no longer occurs.