### PR TITLE
Fix iterator invalidation bug.

### DIFF
--- a/include/boost/interprocess/sync/windows/sync_utils.hpp
+++ b/include/boost/interprocess/sync/windows/sync_utils.hpp
@@ -122,8 +122,9 @@ class sync_handles
 
    //key: id -> mapped: HANDLE. Hash map to allow efficient sync operations
    typedef boost::container::flat_map<sync_id, void*> id_map_type;
-   //key: ordered address of the sync type -> iterator from id_map_type. Ordered map to allow closing handles when unmapping
-   typedef boost::container::flat_map<const void*, id_map_type::iterator> addr_map_type;
+   //key: ordered address of the sync type -> key from id_map_type. Ordered map to allow closing handles when unmapping
+   // Can't store iterators into id_map_type because they would get invalidated.
+   typedef boost::container::flat_map<const void*, sync_id> addr_map_type;
    static const std::size_t LengthOfGlobal = sizeof("Global\\boost.ipc")-1;
    static const std::size_t StrSize        = LengthOfGlobal + (sizeof(sync_id)*2+1);
    typedef char NameBuf[StrSize];
@@ -192,7 +193,7 @@ class sync_handles
       void *&hnd_val = it->second;
       if(!hnd_val){
          BOOST_ASSERT(map_.find(mapping_address) == map_.end());
-         map_[mapping_address] = it;
+         map_[mapping_address] = id;
          hnd_val = open_or_create_mutex(id);
          if(popen_created) *popen_created = true;
          ++num_handles_;
@@ -213,7 +214,7 @@ class sync_handles
       void *&hnd_val = it->second;
       if(!hnd_val){
          BOOST_ASSERT(map_.find(mapping_address) == map_.end());
-         map_[mapping_address] = it;
+         map_[mapping_address] = id;
          hnd_val = open_or_create_semaphore(id, initial_count);
          if(popen_created) *popen_created = true;
          ++num_handles_;
@@ -250,9 +251,11 @@ class sync_handles
                          ithig(map_.lower_bound(hig_id)),
                          it(itlow);
       for (; it != ithig; ++it){
-         id_map_type::iterator uit = it->second; 
+         sync_id ukey = it->second;
+         id_map_type::iterator uit = umap_.find(ukey);
+         BOOST_ASSERT(uit != umap_.end());
          void * const hnd = uit->second;
-         umap_.erase(uit);
+         umap_.erase(ukey);
          int ret = winapi::close_handle(hnd);
          --num_handles_;
          BOOST_ASSERT(ret != 0); (void)ret;  //Sanity check that handle was ok


### PR DESCRIPTION
This fixes https://github.com/boostorg/interprocess/issues/192 and https://github.com/boostorg/interprocess/issues/210 (which seem to describe the same bug).

Here's the code I'm testing this on. I'm using VS 2022 (though some coworkers with the same compiler can't reproduce, I'm not entirely sure why)
```cpp
#define BOOST_INTERPROCESS_FORCE_NATIVE_EMULATION 1 // This is important, doesn't crash otherwise.

#include <boost/interprocess/allocators/allocator.hpp>
#include <boost/interprocess/managed_windows_shared_memory.hpp>
#include <boost/interprocess/smart_ptr/unique_ptr.hpp>
#include <iostream>

int main()
{
    std::cout << "Before\n";
    {
        namespace bip = boost::interprocess;
        // Destructor of `x` crashes.
        auto x = bip::managed_windows_shared_memory( bip::open_or_create, "blah", bip::mapped_region::get_page_size() );
    }
    std::cout << "After\n";
}
```