### PR TITLE
Fix UBSan runtime error (load of 'boost::interprocess::mode_t')

### DIFF
--- a/include/boost/interprocess/detail/file_wrapper.hpp
+++ b/include/boost/interprocess/detail/file_wrapper.hpp
@@ -90,7 +90,8 @@ class file_wrapper
    //!After the call, "moved" does not represent any file.
    //!Does not throw
    file_wrapper(BOOST_RV_REF(file_wrapper) moved)
-      :  m_handle(file_handle_t(ipcdetail::invalid_file()))
+      : m_handle(file_handle_t(ipcdetail::invalid_file())),
+      , m_mode(read_only)
    {  this->swap(moved);   }
 
    //!Moves the ownership of "moved"'s file to *this.


### PR DESCRIPTION
This is similar to commit `4e2c06b24211e4983dad95d4b1035d1e0602490d` "Fix Issue #64 ("UBSan: runtime error: load of value 4294967295 [...] for type 'boost::interprocess::mode_t'". It was triggered on the following line in `interprocess/include/boost/interprocess/detail/managed_open_or_create_impl.hpp`:

```cpp
      if(StoreDevice){                                                                                                                  
         this->DevHolder::get_device() = boost::move(dev);                                                                                                                                                                                                                       
      }                                                                                                                                 
```

`file_wrapper`'s move constructor in `include/boost/interprocess/detail/file_wrapper.hpp` simply does not initialize m_mode. This commit initializes it to `read_only`.