### PR TITLE
Fix inline assembly for armv7 target

### DIFF
--- a/include/boost/interprocess/interprocess_printers.hpp
+++ b/include/boost/interprocess/interprocess_printers.hpp
@@ -13,7 +13,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
         ".ascii \"\\4gdb.inlined-script.BOOST_INTERPROCESS_INTERPROCESS_PRINTERS_HPP\\n\"\n"
         ".ascii \"import gdb.printing\\n\"\n"
 


### PR DESCRIPTION
Related to boostorg/unordered#294, boostorg/unordered#295

This fix is based on ned14/outcome#308