### PR TITLE
Fix 64b segments from 32b code

### DIFF
--- a/include/boost/interprocess/detail/segment_manager_helper.hpp
+++ b/include/boost/interprocess/detail/segment_manager_helper.hpp
@@ -386,7 +386,7 @@ struct block_header
    static size_type value_offset()
    {  return size_type(sizeof(block_header));   }
 
-   template<std::size_t CharAlign>
+   template<size_type CharAlign>
    size_type name_offset() const
    {  return get_rounded_size(this->name_length_offset()+sizeof(name_len_t), CharAlign);  }
 


### PR DESCRIPTION
Fix for code that shares boost::interprocess::basic_managed_shared_memory between a 64b and 32b process as described here: https://stackoverflow.com/a/63224381

Prior code doesn't compile:
detail\segment_manager_helper.hpp(391,14): error : no matching function for call to 'get_rounded_size'

The template parameter type for ipcdetail::block_header<unsigned long long>::name_offset<> is 32b (std::size_t), whereas the other sizes are 64b (uint64_t). This causes the get_rounded_size() template to be rejected since both arguments are not of the same type.

https://github.com/boostorg/interprocess/issues/270