### PR TITLE
Allow injection of custom atexit procedure

### DIFF
--- a/include/boost/interprocess/detail/intermodule_singleton_common.hpp
+++ b/include/boost/interprocess/detail/intermodule_singleton_common.hpp
@@ -421,7 +421,7 @@ class intermodule_singleton_impl
             } BOOST_INTERPROCESS_CATCH_END
          }
          //if(Phoenix){
-            std::atexit(&atexit_work);
+            BOOST_INTERPROCESS_ATEXIT(&atexit_work);
          //}
          atomic_inc32(&rcount->singleton_ref_count);
          ret_ptr = rcount->ptr;

--- a/include/boost/interprocess/detail/workaround.hpp
+++ b/include/boost/interprocess/detail/workaround.hpp
@@ -375,4 +375,8 @@ namespace boost {
 
 #endif   //!defined(DISABLE_BOOST_INTERPROCESS_EINTR_RETRY) && defined(__GNUC__)
 
+#if !defined(BOOST_INTERPROCESS_ATEXIT)
+   #define BOOST_INTERPROCESS_ATEXIT(f) std::atexit((f))
+#endif   //!defined(BOOST_INTERPROCESS_ATEXIT)
+
 #endif   //#ifndef BOOST_INTERPROCESS_DETAIL_WORKAROUND_HPP


### PR DESCRIPTION
I came to a situation where a singleton in my application (let's call it `MySingleton`) with references to some boost interprocess objects was destroyed after the boost interprocess singleton.

The destructor of `MySingleton` was then calling the boost interprocess API to free the relevant resources, and random crashes occurred.

I've been using the following changes for a while now and decided to contribute them back.

