### PR TITLE
AIX build fix: Fix return type in get_invalid_systemwide_thread_id

### DIFF
--- a/include/boost/interprocess/detail/os_thread_functions.hpp
+++ b/include/boost/interprocess/detail/os_thread_functions.hpp
@@ -372,7 +372,7 @@ inline OS_systemwide_thread_id_t get_current_systemwide_thread_id()
 {  return thread_self();   }
 
 inline OS_systemwide_thread_id_t get_invalid_systemwide_thread_id()
-{  return (thread_t)(-1);  }
+{  return (tid_t)(-1);  }
 
 #elif defined(__CYGWIN__) && !defined(BOOST_INTERPROCESS_USE_PTHREAD_AS_SYSTEMWIDE_THREAD_ID)
 


### PR DESCRIPTION
The build fails on AIX with the following error:
```
include/boost/interprocess/detail/os_thread_functions.hpp: In function 'boost::interprocess::ipcdetail::OS_systemwide_thread_id_t boost::interprocess::ipcdetail::get_invalid_systemwide_thread_id()':
include/boost/interprocess/detail/os_thread_functions.hpp:375:12: error: 'thread_t' was not declared in this scope; did you mean 'boost::asio::execution::detail::mapping::thread_t'?
  375 | {  return (thread_t)(-1);  }
      |            ^~~~~~~~
      |            boost::asio::execution::detail::mapping::thread_t
```
It seems that this is caused by a copy paste error from the Solaris implementation in      https://github.com/boostorg/interprocess/commit/bfce9f1e0b5220384c4f4a320775ab9d542d54f6