### PR TITLE
Improvements on rbtree_best_fit::check_sanity

### DIFF
--- a/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
+++ b/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
@@ -651,29 +651,35 @@ bool rbtree_best_fit<MutexFamily, VoidPointer, MemAlignment>::
    //-----------------------
    boost::interprocess::scoped_lock<mutex_type> guard(m_header);
    //-----------------------
-   imultiset_iterator ib(m_header.m_imultiset.begin()), ie(m_header.m_imultiset.end());
-
-   size_type free_memory = 0;
-
-   //Iterate through all blocks obtaining their size
-   for(; ib != ie; ++ib){
-      free_memory += (size_type)ib->m_size*Alignment;
-      if(!algo_impl_t::check_alignment(&*ib))
-         return false;
-   }
 
    //Check allocated bytes are less than size
    if(m_header.m_allocated > m_header.m_size){
       return false;
    }
 
+   //Calculate the maximum free memory available in the segment
    size_type block1_off  =
       priv_first_block_offset_from_this(this, m_header.m_extra_hdr_bytes);
+   size_type max_free_memory = m_header.m_size - block1_off;
 
-   //Check free bytes are less than size
-   if(free_memory > (m_header.m_size - block1_off)){
-      return false;
+   //Iterate through all blocks obtaining their size
+   imultiset_iterator ib(m_header.m_imultiset.begin()), ie(m_header.m_imultiset.end());
+   size_type free_memory = 0;
+   for(; ib != ie; ++ib){
+      if(!algo_impl_t::check_alignment(&*ib)){
+         return false;
+      }
+      //A size of 0 is not allowed in the multiset
+      if(!ib->m_size){
+         return false;
+      }
+      free_memory += (size_type)ib->m_size*Alignment;
+      //Check free bytes are less than size
+      if(free_memory > max_free_memory){
+         return false;
+      }
    }
+
    return true;
 }
 


### PR DESCRIPTION
When checking the sanity of a shared memory segment, if the memory has been corrupted, the iterator might read outside the segment, producing a segfault.

This was found during the investigation of https://github.com/eProsima/Fast-DDS/issues/6501

The proposed changes perform the quick check on the header before the loop.
Inside the loop, the check for the alignment is performed before accessing the data pointed to by the iterator, and the loop returns early whenever the accumulated `free_memory` value exceeds the limit.

This reduces the chance of the iterator jumping to an offset outside the segment.